### PR TITLE
Lambda を Docker(ECR) から zip(provided.al2) へ移行 + GitHub Actions を OIDC 化

### DIFF
--- a/.github/workflows/serverless-dev.yml
+++ b/.github/workflows/serverless-dev.yml
@@ -2,6 +2,11 @@ name: serverless-dev
 
 on: pull_request
 
+# OIDC で AWS の IAM ロールを AssumeRole するために id-token の発行権限が必要。
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     name: deploy
@@ -12,19 +17,20 @@ jobs:
           echo "::add-mask::${{ secrets.API_URL_MASK }}"
 
       - name: setup node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
 
       - name: install sls
         run: npm i -g serverless
 
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          # アクセスキー方式から OIDC(AssumeRoleWithWebIdentity)方式へ移行。
+          # secrets.AWS_ROLE_ARN には ga-deploy-oicd_lambda-csharp-sls の ARN を設定する。
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ap-northeast-1
 
       - name: install plugins

--- a/.github/workflows/serverless-dev.yml
+++ b/.github/workflows/serverless-dev.yml
@@ -27,6 +27,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-1
 
+      - name: install plugins
+        run: npm install
+
       - name: deploy
         run: sls deploy --stage dev
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ bin/
 .vs/
 
 .vscode/
+
+# zip 版でビルド時に生成される成果物・依存
+node_modules/
+bootstrap
+env.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,23 @@
-FROM bitnami/dotnet-sdk:latest as build-image
-
-WORKDIR /work
-COPY ./ ./
-
-RUN dotnet publish -c Release
-RUN mv bin/Release/net6.0/linux-x64/publish/bootstrap bootstrap
-RUN chmod +x bootstrap
-
-FROM public.ecr.aws/lambda/provided:latest
-
-COPY --from=build-image /work/bootstrap /var/runtime/
-
-CMD ["dummyHandler"]
+# =====================================================================
+# Docker(ECR イメージ)版の Dockerfile【旧構成・参考用にコメントアウト】
+# ---------------------------------------------------------------------
+# zip(provided.al2)版へ移行したため未使用。
+# zip 版では serverless.yml の scripts フックが bitnami/dotnet-sdk イメージで
+# `dotnet publish -c Release` を実行して bootstrap を生成するため、
+# この Dockerfile は不要になった。
+# ---------------------------------------------------------------------
+# FROM bitnami/dotnet-sdk:latest as build-image
+#
+# WORKDIR /work
+# COPY ./ ./
+#
+# RUN dotnet publish -c Release
+# RUN mv bin/Release/net6.0/linux-x64/publish/bootstrap bootstrap
+# RUN chmod +x bootstrap
+#
+# FROM public.ecr.aws/lambda/provided:latest
+#
+# COPY --from=build-image /work/bootstrap /var/runtime/
+#
+# CMD ["dummyHandler"]
+# =====================================================================

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "lambda-csharp-sls",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lambda-csharp-sls",
+      "version": "0.1.0",
+      "devDependencies": {
+        "serverless-plugin-scripts": "^1.0.2"
+      }
+    },
+    "node_modules/serverless-plugin-scripts": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/serverless-plugin-scripts/-/serverless-plugin-scripts-1.0.2.tgz",
+      "integrity": "sha512-+OL9fFz5r6BXNHfpu9MDLehS/haC0fy/T3V5uJsTfLAnNsn+PzM6BmvefUfWG372hBT7piTbywB1Vl1+4LmI5Q==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "lambda-csharp-sls",
+  "version": "0.1.0",
+  "private": true,
+  "devDependencies": {
+    "serverless-plugin-scripts": "^1.0.2"
+  }
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,40 +1,96 @@
 service: lambda-csharp-sls
 
+plugins:
+  - serverless-plugin-scripts
+
 custom:
-  defaultAccount: dummy
-  defaultDigest: dummy
   defaultStage: dev
+  scripts:
+    hooks:
+      # sls deploy / sls package 時に bootstrap を発行(publish)する。
+      # macOS / Apple Silicon でも Lambda(provided.al2, x86_64) 互換の
+      # 自己完結バイナリを得るため、linux/amd64 を明示して Docker でビルドする。
+      # RuntimeIdentifier(linux-x64) 指定 + PublishSingleFile により
+      # .NET ランタイム同梱の単一実行ファイル bootstrap が生成される。
+      # chmod はコンテナ内で実行する。Linux ランナーでは生成物の所有者が
+      # コンテナ外の runner ユーザーと異なり chmod できないことがあるため。
+      'before:package:createDeploymentArtifacts': |
+        docker run --rm --platform linux/amd64 -v "$PWD":/work -w /work bitnami/dotnet-sdk:latest \
+          sh -c "dotnet publish -c Release && cp bin/Release/net6.0/linux-x64/publish/bootstrap bootstrap && chmod +x bootstrap"
 
 provider:
   name: aws
-  runtime: provided
+  runtime: provided.al2
   timeout: 20
   region: ap-northeast-1
-  ecr:
-    images:
-      appImage:
-        path: ./
-        platform: linux/amd64
   stage: ${opt:stage, self:custom.defaultStage}
   # environment:
   #   ${file(./env.yml)}
 
+package:
+  patterns:
+    - '!./**'
+    - bootstrap
+
 functions:
+  # provided ランタイムはパッケージ直下の bootstrap を実行する。
+  # handler 文字列は _HANDLER として渡され、src/Main.cs の
+  # Handler("...") と一致させることで処理を振り分ける。
   hello:
-    image:
-      name: appImage
-      command:
-        - hello
+    handler: hello
     events:
       - http:
           path: test
           method: get
   world:
-    image:
-      name: appImage
-      command:
-        - world
+    handler: world
     events:
       - http:
           path: test
           method: post
+
+# =====================================================================
+# Docker(ECR イメージ)版【旧構成・参考用にコメントアウトで残す】
+# ---------------------------------------------------------------------
+# Dockerfile から ECR イメージをビルドし、image.command で各関数の
+# _HANDLER を切り替えていた。zip 版へ移行したため無効化。
+# ---------------------------------------------------------------------
+# custom:
+#   defaultAccount: dummy
+#   defaultDigest: dummy
+#   defaultStage: dev
+#
+# provider:
+#   name: aws
+#   runtime: provided
+#   timeout: 20
+#   region: ap-northeast-1
+#   ecr:
+#     images:
+#       appImage:
+#         path: ./
+#         platform: linux/amd64
+#   stage: ${opt:stage, self:custom.defaultStage}
+#   # environment:
+#   #   ${file(./env.yml)}
+#
+# functions:
+#   hello:
+#     image:
+#       name: appImage
+#       command:
+#         - hello
+#     events:
+#       - http:
+#           path: test
+#           method: get
+#   world:
+#     image:
+#       name: appImage
+#       command:
+#         - world
+#     events:
+#       - http:
+#           path: test
+#           method: post
+# =====================================================================


### PR DESCRIPTION
## 概要
参考リポジトリ [limit7412/lambda-crystal-sls](https://github.com/limit7412/lambda-crystal-sls) に倣い、Lambda のデプロイを Docker(ECR イメージ)版から zip(provided.al2)版へ移行し、あわせて GitHub Actions の AWS 認証を OIDC 化しました。

## 変更点
### zip 移行
- `serverless.yml`: `serverless-plugin-scripts` の `before:package:createDeploymentArtifacts` フックで Docker(`bitnami/dotnet-sdk`)を使い `linux/amd64` の self-contained `bootstrap` を publish → zip パッケージング。runtime を `provided` → `provided.al2`、`ecr` 設定を削除、関数を `image.command` → `handler` に変更
- 旧 Docker 構成は `serverless.yml` / `Dockerfile` にコメントアウトで保持（サンプル実装のため）
- `package.json` / `package-lock.json`: `serverless-plugin-scripts` を追加
- `.gitignore`: `bootstrap` / `node_modules/` / `env.yml` を追加

### OIDC 化
- workflow に `permissions: id-token: write` を追加
- `configure-aws-credentials` をアクセスキー方式 → `role-to-assume`(OIDC) 方式へ変更
- `setup-node` / `checkout` を v4 に更新
- AWS 側: ロール `ga-deploy-oicd_lambda-csharp-sls`(信頼条件 `repo:limit7412/lambda-csharp-sls:*`) を作成
- GitHub 側: secret `AWS_ROLE_ARN` を設定、旧 `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` secret を削除

## 動作確認
- ローカルから docker 版を `sls remove` → zip 版を `sls deploy` 済み
- GET(hello) / POST(world) ともに HTTP 200 を確認済み
- OIDC の実認証は本 PR の Actions デプロイ job で検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)